### PR TITLE
Fix HTTPS Loading bug

### DIFF
--- a/app/assets/javascripts/store/spree_videos.js.erb.coffee
+++ b/app/assets/javascripts/store/spree_videos.js.erb.coffee
@@ -23,7 +23,7 @@ class VideoManager
 		size = @calculateDimensions(true)
 		matches = @options.youtube_match.exec(youtube_link)
 		youtubeID = if matches then matches[matches.length - 1] else youtube_link
-		youtubeURL = "http://www.youtube.com/embed/" + youtubeID + "?origin=" + @options.originDomain + "&" + @options.youtube_options;
+		youtubeURL = "https://www.youtube.com/embed/" + youtubeID + "?origin=" + @options.originDomain + "&" + @options.youtube_options;
 		
 		@player_holder.html('<iframe type="text/html" width="' + size.width + '" height="' + size.height + '" src="' + youtubeURL + '" frameborder="0"></iframe>');
 	

--- a/app/models/spree/video.rb
+++ b/app/models/spree/video.rb
@@ -9,7 +9,7 @@ module Spree
     def youtube_data
       youtube_data = YouTubeIt::Model::Video.new({})
       youtube_data.instance_variable_set(:@unique_id, youtube_ref)
-      youtube_data.instance_variable_set(:@thumbnails, [OpenStruct.new(url: "http://i.ytimg.com/vi/#{youtube_ref}/default.jpg")])
+      youtube_data.instance_variable_set(:@thumbnails, [OpenStruct.new(url: "https://i.ytimg.com/vi/#{youtube_ref}/default.jpg")])
       youtube_data
     end
 

--- a/app/views/spree/products/_video_player.html.erb
+++ b/app/views/spree/products/_video_player.html.erb
@@ -4,7 +4,8 @@ youtube_url_params ||= {}
 html_options ||= {}
 
 html5_config = Spree::Videos.configuration.html_options.merge({
-  :url_params => Spree::Videos.configuration.youtube_url_params.merge(youtube_url_params)
+  :url_params => Spree::Videos.configuration.youtube_url_params.merge(youtube_url_params),
+  :protocol => 'https'
 }).merge(html_options)
 
 # change dimensions if one of the dimensions was defined in the config


### PR DESCRIPTION
Youtube no longer allows fetching content for embeded videos over HTTP when the page making the request was loaded over HTTPS. When this happens, the following error can be seen from the browser's JS console:

> Mixed Content: The page at 'https://...' was loaded over HTTPS, but requested an insecure resource 'http://www.youtube.com/embed/...'. This request has been blocked; the content must be served over HTTPS.

This fixes the bug
